### PR TITLE
Speed up when looping on many single lines

### DIFF
--- a/R/flowgraph.R
+++ b/R/flowgraph.R
@@ -10,7 +10,7 @@ flowgraph <- function(expr) {
     id = rep("", prealloc),
     type = rep("", prealloc)
   )
-  nodeslast <- replicate(prealloc, character())
+  nodeslast <- rep(list(character()), n)
 
   ## The structure of the graph is stored here
   num_edges <- 0

--- a/R/flowgraph.R
+++ b/R/flowgraph.R
@@ -10,7 +10,7 @@ flowgraph <- function(expr) {
     id = rep("", prealloc),
     type = rep("", prealloc)
   )
-  nodeslast <- rep(list(character()), n)
+  nodeslast <- rep(list(character()), prealloc)
 
   ## The structure of the graph is stored here
   num_edges <- 0


### PR DESCRIPTION
The package `lintr` spends a lot of time on `cyclocomp()` because it checks one expression at a time. It seems that most of the time spent by `cyclocomp()` is because of `replicate()`. It is much faster and more memory-efficient to use `rep()` on a list:

``` r
n <- 4000

bench::mark(
  replicate = replicate(n, character()),
  rep = rep(list(character()), n),
  iterations = 100
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 replicate    2.88ms   3.09ms      307.   128.8KB     26.7
#> 2 rep          21.3µs   28.2µs    34470.    31.3KB      0
```

Below is a small example.

**Before:**
``` r
library(cyclocomp)

# create a fake file
tmp <- tempfile()
cat(rep("x = 1\n", 5000), file = tmp)

lines <- readLines(tmp)
bench::mark(
  expr = {
    for (i in lines) {
      cyclocomp(i)
    }
  }
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 expr          26.3s    26.3s    0.0380    1.12GB     9.00
```

**After:**

``` r
library(cyclocomp)

tmp <- tempfile()
cat(rep("x = 1\n", 5000), file = tmp)

lines <- readLines(tmp)
bench::mark(
  expr = {
    for (i in lines) {
      cyclocomp(i)
    }
  }
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 expr          3.84s    3.84s     0.260     765MB     11.7
```

